### PR TITLE
fixed wrong reference number

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ LaravelMyanmarPaymentsFacade::channel("kbz_pay.pwaapp")
     ->getPaymentScreenUrl($orderId, $amount, $nonceStr,  $backendResultUrl)
 # QR Code
 LaravelMyanmarPaymentsFacade::channel("kbz_pay.qr")
-    ->getPaymentScreenUrl($orderId, $amount, $nonceStr,  $backendResultUrl)
+    ->getPaymentQr($orderId, $amount, $nonceStr,  $backendResultUrl)
 
 # In App
 LaravelMyanmarPaymentsFacade::channel("kbz_pay.app")->getPaymentData($orderId, $amount, $nonceStr, $backendResultUrl);


### PR DESCRIPTION
Fix README – wrong method reference

getPaymentScreenUrl() is not available on the 'kbz_pay.qr' channel. Updated example to use the correct method: getPaymentQr(...) for 'kbz_pay.qr'.
<img width="1155" height="295" alt="Screenshot 2568-07-21 at 02 13 07" src="https://github.com/user-attachments/assets/42014947-b20c-4a7e-a819-6615c2841082" />
